### PR TITLE
Correct augmented forth function name in readme

### DIFF
--- a/readme.mdown
+++ b/readme.mdown
@@ -98,7 +98,7 @@ Below is a list of ratios to choose from. By default, the variable `$ratio` is s
 * major-sixth()
 * minor-sixth()
 * fifth()
-* augfourth()
+* augmented-forth()
 * fourth()
 * major-third()
 * minor-third()


### PR DESCRIPTION
Small documentation issue. 

The correct function name should be:  augmented-forth() not augfourth() like it is currently.
