### PR TITLE
Add ratio and decimal values to ratio functions in readme.mdown

### DIFF
--- a/readme.mdown
+++ b/readme.mdown
@@ -80,36 +80,43 @@ You can use multiple $base-sizes and multiple $ratios together
 }
 ```
 
-
 ## Ratios
 
-The included ratios are called by functions. You can add your own ratios as well.
+Modular scale includes functions for a number of classic design and musical scale ratios. You can add your own ratios as well.
 
-Below is a list of ratios to choose from. By default, the variable `$ratio` is set to `golden()`.
+By default, the variable `$ratio` is set to `golden()`.
 
-* golden()
-* double-octave()
-* major-twelfth()
-* major-eleventh()
-* major-tenth()
-* octave()
-* major-seventh()
-* minor-seventh()
-* major-sixth()
-* minor-sixth()
-* fifth()
-* augmented-forth()
-* fourth()
-* major-third()
-* minor-third()
-* major-second()
-* minor-second()
+<table>
+
+  <tr><th>Function</th><th>Ratio</th><th>Decimal value</th></tr>
+
+  <tr><td>golden()</td><td>1:1.618</td><td>1.618</td></tr>
+  <tr><td>double-octave()</td><td>1:4</td><td>4</td></tr>
+  <tr><td>major-twelfth()</td><td>1:3</td><td>3</td></tr>
+  <tr><td>major-eleventh()</td><td>3:8</td><td>2.667</td></tr>
+  <tr><td>major-tenth()</td><td>2.5</td><td>2:5</td></tr>
+  <tr><td>octave()</td><td>1:2</td><td>2</td></tr>
+  <tr><td>major-seventh()</td><td>8:15</td><td>1.875</td></tr>
+  <tr><td>minor-seventh()</td><td>9:16</td><td>1.778</td></tr>
+  <tr><td>major-sixth()</td><td>3:5</td><td>1.667</td></tr>
+  <tr><td>minor-sixth()</td><td>5:8</td><td>1.6</td></tr>
+  <tr><td>fifth()</td><td>2:3</td><td>1.5</td></tr>
+  <tr><td>augmented-forth()</td><td>1:√2</td><td>1.414</td></tr>
+  <tr><td>fourth()</td><td>3:4</td><td>1.333</td></tr>
+  <tr><td>major-third()</td><td>4:5</td><td>1.25</td></tr>
+  <tr><td>minor-third()</td><td>5:6</td><td>1.2</td></tr>
+  <tr><td>major-second()</td><td>8:9</td><td>1.125</td></tr>
+  <tr><td>minor-second()</td><td>15:16</td><td>1.067</td></tr>
+
+</table>
 
 Add your own ratio in Sass by setting a variable and passing that to modular-scale.
 
 ```scss
 $my-variable: 1 / 3.14159265;
+$ratio: $my-variable;
 ```
+
 
 ## Inspiration
 

--- a/readme.mdown
+++ b/readme.mdown
@@ -117,7 +117,6 @@ $my-variable: 1 / 3.14159265;
 $ratio: $my-variable;
 ```
 
-
 ## Inspiration
 
 Sassy Modular Scale was adapted from [modularscale.com](http://modularscale.com/) by Tim Brown ([@nicewebtype](http://twitter.com/nicewebtype)). Tim also wrote a supporting article at [A List Apart](http://www.alistapart.com/) titled ["More Meaningful Typography"](http://www.alistapart.com/articles/more-meaningful-typography/). Additional inspiration goes to [Robert Bringhurst](http://en.wikipedia.org/wiki/Robert_Bringhurst), author of ["The Elements of Typographic Style"](http://en.wikipedia.org/wiki/The_Elements_of_Typographic_Style) - specifically Chapter 8 titled "Shaping the Page"


### PR DESCRIPTION
I find myself going back to http://modularscale.com and clicking the select box to check the numeric and decimal values of the named ratio functions in Modular Scale, either to match them to a known ratio or to get some idea without testing them how much distance between steps they're going to give me. 

I rewrote the readme function list as a table with both pieces of information. I would have preferred to just inline the ratio/deimal with 50% lighter text, but I don't think there's any way to do that with github flavored markdown. If you'd like to merge, please do, but if you think it clutters the readme I'll just keep it for personal use.
