### PR TITLE
Correct "augmented-forth" typo.

### DIFF
--- a/lib/modular-scale.rb
+++ b/lib/modular-scale.rb
@@ -64,7 +64,7 @@ module Sass::Script::Functions
     value = 3 / 2.0
     Sass::Script::Number.new(value)
   end
-  def augmented_forth
+  def augmented_fourth
     value = Math.sqrt(2) / 1.0
     Sass::Script::Number.new(value)
   end

--- a/readme.mdown
+++ b/readme.mdown
@@ -101,7 +101,7 @@ By default, the variable `$ratio` is set to `golden()`.
   <tr><td>major-sixth()</td><td>3:5</td><td>1.667</td></tr>
   <tr><td>minor-sixth()</td><td>5:8</td><td>1.6</td></tr>
   <tr><td>fifth()</td><td>2:3</td><td>1.5</td></tr>
-  <tr><td>augmented-forth()</td><td>1:√2</td><td>1.414</td></tr>
+  <tr><td>augmented-fourth()</td><td>1:√2</td><td>1.414</td></tr>
   <tr><td>fourth()</td><td>3:4</td><td>1.333</td></tr>
   <tr><td>major-third()</td><td>4:5</td><td>1.25</td></tr>
   <tr><td>minor-third()</td><td>5:6</td><td>1.2</td></tr>

--- a/test/config.rb
+++ b/test/config.rb
@@ -81,7 +81,7 @@ module Sass::Script::Functions
     value = 3 / 2.0
     Sass::Script::Number.new(value)
   end
-  def augmented_forth
+  def augmented_fourth
     value = Math.sqrt(2) / 1.0
     Sass::Script::Number.new(value)
   end

--- a/test/sass/example.scss
+++ b/test/sass/example.scss
@@ -7,7 +7,7 @@
 // $base-size: 1em 2.75em; // 16px, 44px
 // $base-size: 1rem 2.75rem; // 16px, 44px
 // $base-size: 1em;
-// $ratio: augmented_forth();
+// $ratio: augmented_fourth();
 // $ratio: golden_ratio() major_third();
 // $round_pixels: false;
 //


### PR DESCRIPTION
Switch from spreading augmentation far and wide to the [sinister musical chord](http://www.guardian.co.uk/notesandqueries/query/0,,-1767,00.html) name.

This will break current usages of `augmented_forth()`. Not sure what to do about that.
