### PR TITLE
Update gem dependency version for sassy-math

### DIFF
--- a/modular-scale.gemspec
+++ b/modular-scale.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubygems_version = %q{1.3.6}
   s.add_dependency("compass", [">= 0.11.5"])
-  s.add_dependency("sassy-math", [">= 1.2"])
+  s.add_dependency("sassy-math", [">= 1.5"])
 end


### PR DESCRIPTION
To prevent conflict with old `rand()` function interference. See https://github.com/bookcasey/harsh/issues/7
