### PR TITLE
Fix typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
   "ignore": [
     "lib",
     "test-compass",
-    "test-note-sass"
+    "test-node-sass"
   ]
 }


### PR DESCRIPTION
Bower is not ignoring the node-sass tests, resulting in 33 MB of additional files.
