### PR TITLE
Fix wiredep 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "v2.0.6",
   "main": [
     "stylesheets/_modular-scale.scss",
-    "stylesheets/modular-scale/*"
   ],
   "ignore": [
     "lib",


### PR DESCRIPTION
It doesn't make sense to include _every_ partial `scss` file in bower's `main` array, because they are already included in the main `_modular-scale.scss` file. 

This causes issues when using bower injectors such as [wiredep](https://github.com/stephenplusplus/grunt-wiredep), which then unnecessarily include every `modularscale` `scss` file, instead of the primary `_modular-scale.scss` one:

`````` css
// bower:scss
@import "../../bower_components/modular-scale/stylesheets/_modular-scale.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_calc.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_function-list.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_function.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_generate-list.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_pow.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_ratios.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_respond.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_round-px.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_sort-list.scss";
@import "../../bower_components/modular-scale/stylesheets/modular-scale/_tests.scss";
// endbower```
``````
