### PR TITLE
Remove trailing comma in Main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "modular-scale",
   "version": "v2.0.6",
   "main": [
-    "stylesheets/_modular-scale.scss",
+    "stylesheets/_modular-scale.scss"
   ],
   "ignore": [
     "lib",


### PR DESCRIPTION
Causing bower installs to break! Can't have trailing commas in arrays in JSON

Hyper critical. Bower install fails because of this.
