### PR TITLE
Full support of non-integer exponents in all sass variations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.lock
 
 stylesheets/modular-scale.zip
+
+node_modules

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/modularscale/modularscale-sass/issues"
   },
-  "homepage": "https://github.com/modularscale/modularscale-sass"
+  "homepage": "https://github.com/modularscale/modularscale-sass",
+  "dependencies": {
+    "eyeglass-math": "^1.0.1"
+  }
 }

--- a/stylesheets/modular-scale/_pow-polyfill.scss
+++ b/stylesheets/modular-scale/_pow-polyfill.scss
@@ -1,0 +1,81 @@
+//
+// By drtimofey, script based on davidkpiano, see these links:
+// https://github.com/thoughtbot/bitters/issues/167
+// https://github.com/thoughtbot/bourbon/issues/717
+// https://gist.github.com/davidkpiano/ad6e6771df050ff3727f
+//
+
+@function math-pow-polyfill($number, $exp) {
+  @if (round($exp) != $exp) {
+    @return math-exp($exp * math-ln($number));
+  }
+
+  // Traditional method for integers
+  $value: 1;
+
+  @if $exp > 0 {
+    @for $i from 1 through $exp {
+      $value: $value * $number;
+    }
+  }
+  @else if $exp < 0 {
+    @for $i from 1 through -$exp {
+      $value: $value / $number;
+    }
+  }
+
+  @return $value;
+}
+
+@function math-factorial($value) {
+  @if $value == 0 {
+    @return 1;
+  }
+
+  $result: 1;
+
+  @for $index from 1 through $value {
+    $result: $result * $index;
+  }
+
+  @return $result;
+}
+
+@function math-summation($iteratee, $input, $initial: 0, $limit: 100) {
+  $sum: 0;
+
+  @for $index from $initial to $limit {
+    $sum: $sum + call($iteratee, $input, $index);
+  }
+
+  @return $sum;
+}
+
+@function math-exp-maclaurin($x, $n) {
+  $result: math-pow-polyfill($x, $n) / math-factorial($n);
+  @return $result;
+}
+@function math-exp($value) {
+  $result: math-summation(math-exp-maclaurin, $value, 0, 100);
+  @return $result;
+}
+
+@function math-ln-maclaurin($x, $n) {
+  $result: (math-pow-polyfill(-1, $n + 1) / $n) * (math-pow-polyfill($x - 1, $n));
+  @return $result;
+}
+
+@function math-ln($value) {
+  $ten-exp: 1;
+  $ln-ten: 2.30258509;
+
+  @while ($value > math-pow-polyfill(10, $ten-exp)) {
+    $ten-exp: $ten-exp + 1;
+  }
+
+  $value: $value / math-pow-polyfill(10, $ten-exp);
+
+  $result: math-summation(math-ln-maclaurin, $value, 1, 100);
+
+  @return $result + $ten-exp * $ln-ten;
+}

--- a/stylesheets/modular-scale/_pow-polyfill.scss
+++ b/stylesheets/modular-scale/_pow-polyfill.scss
@@ -1,5 +1,5 @@
 //
-// By drtimofey, script based on davidkpiano, see these links:
+// By drtimofey, script based on script by davidkpiano, see these links:
 // https://github.com/thoughtbot/bitters/issues/167
 // https://github.com/thoughtbot/bourbon/issues/717
 // https://gist.github.com/davidkpiano/ad6e6771df050ff3727f

--- a/stylesheets/modular-scale/_pow.scss
+++ b/stylesheets/modular-scale/_pow.scss
@@ -1,40 +1,20 @@
-// If a native exponent function doesnt exist
-// this one is needed.
+// pow with non-integer exponents
+// feature detection + polyfill
+
+// indirectly checks for eyeglass-math math-pow() existence
+@function pow-nonint-ok() {
+  // using some well-known input/output
+  $test: math-pow(9, 0.5);
+    // => 3 when pow works correctly with non-integer exponents
+  @return ($test == 3);
+}
+$pow-nonint-ok: pow-nonint-ok(); // cache result to improve performance
+
+@import '_pow-polyfill';
 @function ms-pow($Base, $Exponent) {
-
-  // Find and remove unit.
-  // Avoids messyness with unit calculations
-  $Unit: $Base * 0 + 1;
-  $Base: $Base/$Unit;
-
-  // This function doesnt support non-interger exponents.
-  // Warn the user about why this is breaking.
-	@if round($Exponent) != $Exponent {
-		@warn "Unfortunately, you need Compass to use non-integer exponents";
-	}
-
-  // Set up the loop, priming the return with the base.
-	$Return: $Base;
-
-  // If the number is positive, multiply it.
-  @if $Exponent > 0 {
-    // Basic feedback loop as exponents
-    // are recursivley multiplied numbers.
-    @for $i from 1 to $Exponent {
-      $Return: $Return * $Base;
-    }
+  @if($pow-nonint-ok == false) {
+    @return math-pow-polyfill($Base, $Exponent); // use polyfill pow
+  } @else {
+    @return math-pow($Base, $Exponent);          // use eyeglass-math pow
   }
-
-  // If the number is 0 or negitive
-  // divide instead of multiply.
-  @else {
-    // Libsass doesnt allow negitive values in loops
-    @for $i from (-1 + 1) to (abs($Exponent) + 1) {
-      $Return: $Return / $Base;
-    }
-  }
-
-  // Return is now compounded redy to be returned.
-  // Add the unit back onto the number.
-	@return $Return * $Unit;
 }


### PR DESCRIPTION
This PR will add eyeglass-math as package dependency (for eyeglass users), 
a feature detection for pow() supporting non-integer exponents 
and a pow() polyfill that supports non-integer exponents.

_eyeglass_ users can install modularscale-sass package as usual, no further intervention required, 
pow() (so modularscale) will work with non-integer exponents nicely and very fast 
(using eyeglass-math pow native javascript function).

_plain libsass_ users and users of _ruby sass without compass_ can also enjoy non-integer exponents 
as the polyfill is used automatically, also no further intervention required, performance shouldn't be different.

With best regards
