### PR TITLE
Declare eyeglass version (fixes #114)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "eyeglass": {
     "exports": "eyeglass-exports.js",
-    "name": "modular-scale"
+    "name": "modular-scale",
+    "needs": "^0.6.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I went with 0.6.2 because that was the earliest version I could test (earlier versions threw a fatal error during installation).
