### PR TITLE
Add parameter to ms-respond() to render all rules with !important

### DIFF
--- a/stylesheets/modularscale/_respond.scss
+++ b/stylesheets/modularscale/_respond.scss
@@ -9,12 +9,18 @@
 }
 
 // Main responsive mixin
-@mixin ms-respond($prop, $val, $map: $modularscale) {
+@mixin ms-respond($prop, $val, $map: $modularscale, $ms-important: false) {
   $base: $ms-base;
   $ratio: $ms-ratio;
 
   $first-write: true;
   $last-break: null;
+
+  $important: '';
+
+  @if $ms-important == true {
+    $important: ' !important';
+  }
 
   // loop through all settings with a breakpoint type value
   @each $v, $s in $map {
@@ -23,7 +29,7 @@
 
         // Write out the first value without a media query.
         @if $first-write {
-          #{$prop}: ms-function($val, $thread: $v, $settings: $map);
+          #{$prop}: ms-function($val, $thread: $v, $settings: $map)#{$important};
 
           // Not the first write anymore, reset to false to move on.
           $first-write: false;
@@ -35,7 +41,7 @@
           @media (min-width: $last-break) and (max-width: $v) {
             $val1: ms-function($val, $thread: $last-break, $settings: $map);
             $val2: ms-function($val, $thread: $v, $settings: $map);
-            #{$prop}: ms-fluid($val1,$val2,$last-break,$v);
+            #{$prop}: ms-fluid($val1,$val2,$last-break,$v)#{$important};
           }
           $last-break: $v;
         }
@@ -46,7 +52,7 @@
   // Write the last breakpoint.
   @if $last-break {
     @media (min-width: $last-break) {
-      #{$prop}: ms-function($val, $thread: $last-break, $settings: $map);
+      #{$prop}: ms-function($val, $thread: $last-break, $settings: $map)#{$important};
     }
   }
 }


### PR DESCRIPTION
To use modularscale with utility classes in [inuitcss](https://github.com/inuitcss/inuitcss/blob/develop/utilities/_utilities.headings.scss) they have to render with `!important` to follow the inuit specifity convention (keeping a "flat" specifity tree across elements and components but let single purpose utility classes trump everything else, intentionally).

This changes the signature of `ms-respond()` but does not break anything since the additional parameter can be omitted entirely.