### PR TITLE
Mark module as compatible with eyeglass v1 & v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "eyeglass": {
     "exports": "eyeglass-exports.js",
     "name": "modularscale",
-    "needs": "^1.2.1"
+    "needs": "^1.2.1 || ^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/test-eyeglass/.gitignore
+++ b/test-eyeglass/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+.eyeglass-cache

--- a/test-eyeglass/build.js
+++ b/test-eyeglass/build.js
@@ -1,0 +1,16 @@
+const sass = require('node-sass');
+const eyeglass = require('eyeglass');
+const path = require('path');
+
+sass.render(
+  eyeglass({ file: path.join(__dirname, 'main.scss') }),
+  (err, res) => {
+    if (err) {
+      console.error(err.stack);
+      process.exitCode = 1;
+      return;
+    } else {
+      console.log(res.css.toString());
+    }
+  }
+);

--- a/test-eyeglass/main.scss
+++ b/test-eyeglass/main.scss
@@ -1,0 +1,56 @@
+@import 'modularscale';
+
+$modularscale: (
+  base: 16px,
+  ratio: 1.5
+);
+
+@debug ms(-1);
+@debug ms();
+@debug ms(0);
+@debug ms(1);
+@debug ms(2);
+
+$modularscale: (
+  base: 1em,
+  ratio: 1.3,
+  20em: (
+    ratio: 1.3
+  ),
+  60em: (
+    ratio: 1.6
+  ),
+);
+
+body {
+  line-height: 1.3;
+  margin: 0 auto;
+  padding: 10% 5% 50%;
+  max-width: 42em;
+  font-size: ms(0);
+}
+
+h1 {
+  @include ms-respond(font-size, 5);
+  line-height: 1;
+}
+h2 {
+  @include ms-respond(font-size, 4);
+  line-height: 1;
+}
+h3 {
+  @include ms-respond(font-size, 3);
+  line-height: 1;
+}
+h4 {
+  @include ms-respond(font-size, 2);
+  line-height: 1;
+}
+h5 {
+  @include ms-respond(font-size, 1);
+  line-height: 1;
+}
+h6 {
+  @include ms-respond(font-size, 0);
+  line-height: 1;
+}

--- a/test-eyeglass/package.json
+++ b/test-eyeglass/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-eyeglass",
+  "version": "0.0.0",
+  "scripts": {
+    "build-css": "node build.js"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "eyeglass": "^2.4.1",
+    "node-sass": "^4.12.0"
+  },
+  "dependencies": {
+    "modularscale-sass": "file:.."
+  }
+}


### PR DESCRIPTION
Fixes #162 

I've just marked the module as compatible with v2 as well as v1. The only breaking change introduced in v2 was dropping support for node v4 and node v5.

On top of that, I've added a test project for eyeglass. It builds a css file by pulling modularscale-sass though eyeglass